### PR TITLE
Added Test to Check Flow Output

### DIFF
--- a/__tests__/from-schema-test.ts
+++ b/__tests__/from-schema-test.ts
@@ -1,3 +1,5 @@
+import { spawnSync } from 'child_process';
+
 import { schemaToInterfaces, generateNamespace } from '../packages/from-schema/src';
 import { DEFAULT_OPTIONS } from '../packages/language-typescript/src';
 import FLOW_OPTIONS from '../packages/language-flow/src';
@@ -29,6 +31,16 @@ describe('gql2ts', () => {
       );
 
       expect(actual).toMatchSnapshot();
+
+      // Check Flow Output
+      const { stdout, stderr, status } =
+        spawnSync('flow', ['check-contents'], { input: actual });
+
+      if (status !== 0) {
+        console.log(stdout.toString());
+        console.log(stderr.toString());
+      }
+      expect(status).toEqual(0);
     });
 
     it('correctly ignores types', () => {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "description": "Convert GraphQL Schema to TypeScript defs",
   "dependencies": {
+    "flow-bin": "^0.62.0",
     "graphql": ">= 0.10 <0.12"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1061,6 +1061,10 @@ find-up@^2.0.0, find-up@^2.1.0:
   dependencies:
     locate-path "^2.0.0"
 
+flow-bin@^0.62.0:
+  version "0.62.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.62.0.tgz#14bca669a6e3f95c0bc0c2d1eb55ec4e98cb1d83"
+
 for-in@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"


### PR DESCRIPTION
Hey,

I've added a test to check whether the output generated by this code is valid according to flow. It seems that currently, the `Node` type occurs twice.

```
      163:   export type Node = {
                         ^^^^ Node. name is already bound
      158:   type Node = Film | Species | Planet | Person | Starship | Vehicle;
                  ^^^^ type Node
```

Thanks for this!